### PR TITLE
[GCC] support remote execution

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,3 +3,11 @@
 # Build using platforms by default
 build --incompatible_enable_cc_toolchain_resolution
 build --platforms=@riscv_none_elf//platforms:riscv_none_generic
+
+# Remote builds
+build:remote --genrule_strategy=remote
+build:remote --remote_download_minimal
+build:remote --remote_executor=grpc://localhost:8980
+
+# Linux host (used for remote builds)
+build:linux --extra_execution_platforms=//platforms/host:linux

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,6 +14,6 @@ jobs:
           bazelisk build //examples/...
       - name: remote execution
         run: |
-          git clone https://github.com/bazelbuild/bazel-buildfarm /temp/bazel-buildfarm
-          cd /temp/bazel-buildfarm && ./examples/bf-run start && popd
+          git clone https://github.com/bazelbuild/bazel-buildfarm
+          cd bazel-buildfarm && ./examples/bf-run start && cd ..
           bazelisk build --config=remote --config=linux //examples/...

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,3 +12,8 @@ jobs:
       - name: build examples
         run: |
           bazelisk build //examples/...
+      - name: remote execution
+        run: |
+          git clone https://github.com/bazelbuild/bazel-buildfarm /temp/bazel-buildfarm
+          cd /temp/bazel-buildfarm && ./examples/bf-run start && popd
+          bazelisk build --config=remote --config=linux //examples/...

--- a/BUILD
+++ b/BUILD
@@ -89,6 +89,15 @@ filegroup(
 )
 
 filegroup(
+    name = "size",
+    srcs = select({
+        "darwin": ["@riscv_none_elf_darwin_x86_64//:bin/riscv-none-elf-size"],
+        "linux": ["@riscv_none_elf_linux_x86_64//:bin/riscv-none-elf-size"],
+        "windows": ["@riscv_none_elf_windows_x86_32//:bin/riscv-none-elf-size.exe"],
+    }),
+)
+
+filegroup(
     name = "as",
     srcs = select({
         "darwin": ["@riscv_none_elf_darwin_x86_64//:bin/riscv-none-elf-as"],

--- a/examples/baremetal/BUILD
+++ b/examples/baremetal/BUILD
@@ -29,3 +29,11 @@ genrule(
     cmd = "$(execpath @riscv_none_elf//:objcopy) -O ihex $< $@",
     tools = ["@riscv_none_elf//:objcopy"],
 )
+
+genrule(
+    name = "size",
+    srcs = [":baremetal"],
+    outs = ["baremetal.size"],
+    cmd = "$(execpath @riscv_none_elf//:size) $< > $@",
+    tools = ["@riscv_none_elf//:size"],
+)

--- a/examples/baremetal/startup/riscv.bzl
+++ b/examples/baremetal/startup/riscv.bzl
@@ -7,24 +7,10 @@ COPTS = ARCH + [
     "-c",
     "-Wall",
     "-Wextra",
-    # "-O0",
-    # "-g",
     "-fmessage-length=0",
-    # "--specs=nosys.specs",
     "-mcmodel=medlow",
 ]
 
 LINKOPTS = ARCH + [
-    # "-Wall",
-    # "-Wl,--no-relax",
-    # "-Wl,--gc-sections",
     "-nostdlib",
-    # "-nostartfiles",
-    # "-lc",
-    # "-lgcc",
-    # "--specs=nosys.specs",
-    # "-march=rv32imc",
-    # "-mabi=ilp32",
-    # "-mcmodel=medlow",
-    # "-Bstatic",
 ]

--- a/examples/c/BUILD
+++ b/examples/c/BUILD
@@ -42,3 +42,11 @@ genrule(
     cmd = "$(execpath @riscv_none_elf//:objcopy) -O ihex $< $@",
     tools = ["@riscv_none_elf//:objcopy"],
 )
+
+genrule(
+    name = "mock_size",
+    srcs = [":mock_binary"],
+    outs = ["mock.size"],
+    cmd = "$(execpath @riscv_none_elf//:size) $< > $@",
+    tools = ["@riscv_none_elf//:size"],
+)

--- a/platforms/host/BUILD
+++ b/platforms/host/BUILD
@@ -1,0 +1,7 @@
+platform(
+    name = "linux",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)

--- a/toolchain/config.bzl
+++ b/toolchain/config.bzl
@@ -19,26 +19,22 @@ def _impl(ctx):
         wrapper_path(ctx, "strip"),
     ]
 
-    include_flags = [
-        "-I",
+    include_paths = [
         "external/{}/riscv-none-elf/include".format(ctx.attr.gcc_repo),
-        "-I",
         "external/{}/lib/gcc/riscv-none-elf/{}/include".format(ctx.attr.gcc_repo, ctx.attr.gcc_version),
-        "-I",
         "external/{}/lib/gcc/riscv-none-elf/{}/include-fixed".format(ctx.attr.gcc_repo, ctx.attr.gcc_version),
-        "-I",
         "external/{}/riscv-none-elf/include/c++/{}/".format(ctx.attr.gcc_repo, ctx.attr.gcc_version),
-        "-I",
         "external/{}/riscv-none-elf/include/c++/{}/riscv-none-elf/".format(ctx.attr.gcc_repo, ctx.attr.gcc_version),
     ]
 
-    linker_flags = [
-        "-L",
+    linker_paths = [
         "external/{}/riscv-none-elf/lib".format(ctx.attr.gcc_repo),
-        "-L",
         "external/{}/lib/gcc/riscv-none-elf/{}".format(ctx.attr.gcc_repo, ctx.attr.gcc_version),
-        "-llibc.a",
-        "-llibgcc.a",
+    ]
+
+    libs = [
+        "libc.a",
+        "libgcc.a",
     ]
 
     toolchain_compiler_flags = feature(
@@ -59,7 +55,10 @@ def _impl(ctx):
                     ACTION_NAMES.clif_match,
                 ],
                 flag_groups = [
-                    flag_group(flags = include_flags),
+                    flag_group(flags = ["-I%{include_paths}"], iterate_over = "include_paths"),
+                    flag_group(flags = [
+                        "-no-canonical-prefixes",
+                    ]),
                 ],
             ),
         ],
@@ -74,7 +73,11 @@ def _impl(ctx):
                     ACTION_NAMES.linkstamp_compile,
                 ],
                 flag_groups = [
-                    flag_group(flags = linker_flags),
+                    flag_group(flags = ["-L%{linker_paths}"], iterate_over = "linker_paths"),
+                    flag_group(flags = ["-l%{libs}"], iterate_over = "libs"),
+                    flag_group(flags = [
+                        "-no-canonical-prefixes",
+                    ]),
                 ],
             ),
         ],

--- a/toolchain/riscv-none-elf/darwin_x86_64/BUILD
+++ b/toolchain/riscv-none-elf/darwin_x86_64/BUILD
@@ -41,6 +41,7 @@ filegroup(
     name = "ar_files",
     srcs = [
         "riscv-none-elf-ar",
+        "@{}//:compiler_pieces".format(compiler),
         "@{}//:ar".format(compiler),
     ],
 )

--- a/toolchain/riscv-none-elf/linux_aarch64/BUILD
+++ b/toolchain/riscv-none-elf/linux_aarch64/BUILD
@@ -41,6 +41,7 @@ filegroup(
     name = "ar_files",
     srcs = [
         "riscv-none-elf-ar",
+        "@{}//:compiler_pieces".format(compiler),
         "@{}//:ar".format(compiler),
     ],
 )

--- a/toolchain/riscv-none-elf/linux_x86_64/BUILD
+++ b/toolchain/riscv-none-elf/linux_x86_64/BUILD
@@ -41,6 +41,7 @@ filegroup(
     name = "ar_files",
     srcs = [
         "riscv-none-elf-ar",
+        "@{}//:compiler_pieces".format(compiler),
         "@{}//:ar".format(compiler),
     ],
 )

--- a/toolchain/riscv-none-elf/windows_x86_32/BUILD
+++ b/toolchain/riscv-none-elf/windows_x86_32/BUILD
@@ -41,6 +41,7 @@ filegroup(
     name = "ar_files",
     srcs = [
         "riscv-none-elf-ar.bat",
+        "@{}//:compiler_pieces".format(compiler),
         "@{}//:ar".format(compiler),
     ],
 )


### PR DESCRIPTION
# Description

Allow fully hermetic builds for remote execution, fixing a couple of issues with the previous toolchain config:

- [x] add `size` tool
- [x] fix AR dependencies on compiler files
- [x] add system headers, but not as implicit dependencies 