### PR TITLE
[TOOLCHAIN] use aliased repos

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# In code review, collapse generated files
+MODULE.bazel.lock linguist-generated=true

--- a/.github/tools/release.sh
+++ b/.github/tools/release.sh
@@ -24,15 +24,7 @@ bazel_dep(name = "toolchains_riscv_gnu", version = "${TAG:1}")
 # Toolchains: riscv-none-elf
 riscv_toolchain = use_extension("@toolchains_riscv_gnu//:extensions.bzl", "riscv_toolchain")
 riscv_toolchain.riscv_none_elf(version = "13.2.1")
-use_repo(
-    riscv_toolchain,
-    "riscv_none_elf",
-    "riscv_none_elf_darwin_arm64",
-    "riscv_none_elf_darwin_x86_64",
-    "riscv_none_elf_linux_aarch64",
-    "riscv_none_elf_linux_x86_64",
-    "riscv_none_elf_windows_x86_64",
-)
+use_repo(riscv_toolchain, "riscv_none_elf")
 
 register_toolchains("@riscv_none_elf//toolchain:all")
 \`\`\`

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@
 
 module(
     name = "toolchains_riscv_gnu",
-    version = "0.0.1",
+    version = "1.0.0",
     compatibility_level = 1,
 )
 
@@ -11,15 +11,7 @@ bazel_dep(name = "rules_cc", version = "0.0.9")
 
 riscv_toolchain = use_extension("@toolchains_riscv_gnu//:extensions.bzl", "riscv_toolchain")
 riscv_toolchain.riscv_none_elf(version = "13.2.0-2")
-use_repo(
-    riscv_toolchain,
-    "riscv_none_elf",
-    "riscv_none_elf_darwin_arm64",
-    "riscv_none_elf_darwin_x86_64",
-    "riscv_none_elf_linux_aarch64",
-    "riscv_none_elf_linux_x86_64",
-    "riscv_none_elf_windows_x86_64",
-)
+use_repo(riscv_toolchain, "riscv_none_elf")
 
 # DEV ONLY (not needed for release)
 bazel_dep(name = "aspect_bazel_lib", version = "2.0.0", dev_dependency = True)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 6,
-  "moduleFileHash": "6cff04b693e4626bff8cc6cc40be5600db62fb4ebdcfdcba8155b3447eb0d1bd",
+  "moduleFileHash": "fb57150aea2173cced05e885cbc8bb8dc3ba05836cd8ba7774b4856f5d3b1fc1",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -18,7 +18,7 @@
   "moduleDepGraph": {
     "<root>": {
       "name": "toolchains_riscv_gnu",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "key": "<root>",
       "repoName": "toolchains_riscv_gnu",
       "executionPlatformsToRegister": [],
@@ -37,12 +37,7 @@
             "column": 32
           },
           "imports": {
-            "riscv_none_elf": "riscv_none_elf",
-            "riscv_none_elf_darwin_arm64": "riscv_none_elf_darwin_arm64",
-            "riscv_none_elf_darwin_x86_64": "riscv_none_elf_darwin_x86_64",
-            "riscv_none_elf_linux_aarch64": "riscv_none_elf_linux_aarch64",
-            "riscv_none_elf_linux_x86_64": "riscv_none_elf_linux_x86_64",
-            "riscv_none_elf_windows_x86_64": "riscv_none_elf_windows_x86_64"
+            "riscv_none_elf": "riscv_none_elf"
           },
           "devImports": [],
           "tags": [
@@ -1216,7 +1211,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%riscv_toolchain": {
       "general": {
-        "bzlTransitiveDigest": "wdvCAcuxVyAT9QoYoJXj4TOakKLWj0D1JHd82lQMt+U=",
+        "bzlTransitiveDigest": "A6S+kpwcmnOEF5yqoTPAnu3jI4FZH1dwFgRHm+mlPrw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1229,7 +1224,11 @@
               "version": "13.2.0-2",
               "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-darwin-x64.tar.gz",
               "sha256": "72e65bcad6360eb059096a0fb77f3e3e6c618b1281b89648056c95d1b2749466",
-              "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2"
+              "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2",
+              "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:x86_64"
+              ]
             }
           },
           "riscv_none_elf_linux_x86_64": {
@@ -1240,7 +1239,11 @@
               "version": "13.2.0-2",
               "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz",
               "sha256": "52545afb900200fbf65fe05f7ce7090b8a42c64091f4f5d43cae6bb68ea2434a",
-              "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2"
+              "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2",
+              "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:x86_64"
+              ]
             }
           },
           "riscv_none_elf_windows_x86_64": {
@@ -1251,7 +1254,11 @@
               "version": "13.2.0-2",
               "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-win32-x64.zip",
               "sha256": "28ce9f0cfa09f8d4c638a59fb4e17e3f61c80c47e46f11b2ba505a2a3db602f8",
-              "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2"
+              "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2",
+              "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64"
+              ]
             }
           },
           "riscv_none_elf": {
@@ -1260,7 +1267,29 @@
             "attributes": {
               "toolchain_name": "riscv_none_elf",
               "toolchain_prefix": "riscv-none-elf",
-              "version": "13.2.0-2"
+              "version": "13.2.0-2",
+              "hosts": {
+                "riscv_none_elf_darwin_arm64": [
+                  "@platforms//os:macos",
+                  "@platforms//cpu:arm64"
+                ],
+                "riscv_none_elf_darwin_x86_64": [
+                  "@platforms//os:macos",
+                  "@platforms//cpu:x86_64"
+                ],
+                "riscv_none_elf_linux_aarch64": [
+                  "@platforms//os:linux",
+                  "@platforms//cpu:arm64"
+                ],
+                "riscv_none_elf_linux_x86_64": [
+                  "@platforms//os:linux",
+                  "@platforms//cpu:x86_64"
+                ],
+                "riscv_none_elf_windows_x86_64": [
+                  "@platforms//os:windows",
+                  "@platforms//cpu:x86_64"
+                ]
+              }
             }
           },
           "riscv_none_elf_linux_aarch64": {
@@ -1271,7 +1300,11 @@
               "version": "13.2.0-2",
               "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-arm64.tar.gz",
               "sha256": "1c981c611a38dfe5af902089aed570d4dd501eb4ed88d801043e59ab9a62a86a",
-              "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2"
+              "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2",
+              "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:arm64"
+              ]
             }
           },
           "riscv_none_elf_darwin_arm64": {
@@ -1282,15 +1315,34 @@
               "version": "13.2.0-2",
               "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-darwin-arm64.tar.gz",
               "sha256": "dfe3123e5e5093b165eaaf18401b802cbb8697f5ec9b0f5cfd99c45e848fd8a7",
-              "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2"
+              "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2",
+              "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:arm64"
+              ]
             }
           }
         },
         "recordedRepoMappingEntries": [
           [
             "",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "",
+            "rules_cc",
+            "rules_cc~"
+          ],
+          [
+            "",
             "toolchains_riscv_gnu",
             ""
+          ],
+          [
+            "rules_cc~",
+            "bazel_tools",
+            "bazel_tools"
           ]
         ]
       }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1211,7 +1211,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%riscv_toolchain": {
       "general": {
-        "bzlTransitiveDigest": "A6S+kpwcmnOEF5yqoTPAnu3jI4FZH1dwFgRHm+mlPrw=",
+        "bzlTransitiveDigest": "L1TS3AhUnqkOqZ2FTljZLx0xqt0TfPAn3LoI4/q4wLs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/README.md
+++ b/README.md
@@ -57,20 +57,12 @@ build --incompatible_enable_cc_toolchain_resolution
 ## Bzlmod
 
 ```python
-bazel_dep(name = "toolchains_riscv_gnu", version = "0.0.1")
+bazel_dep(name = "toolchains_riscv_gnu", version = "<module_version>")
 
 # Toolchains: riscv-none-elf
 riscv_toolchain = use_extension("@toolchains_riscv_gnu//:extensions.bzl", "riscv_toolchain")
-riscv_toolchain.riscv_none_elf(version = "13.2.1")
-use_repo(
-    riscv_toolchain,
-    "riscv_none_elf",
-    "riscv_none_elf_darwin_arm64",
-    "riscv_none_elf_darwin_x86_64",
-    "riscv_none_elf_linux_aarch64",
-    "riscv_none_elf_linux_x86_64",
-    "riscv_none_elf_windows_x86_64",
-)
+riscv_toolchain.riscv_none_elf(version = "<gcc_version>")
+use_repo(riscv_toolchain, "riscv_none_elf")
 
 register_toolchains("@riscv_none_elf//toolchain:all")
 ```
@@ -104,14 +96,15 @@ Now Bazel will automatically use `riscv-none-elf-gcc` as a compiler.
 
 ## Custom toolchain
 
-If you want to bake certain compiler flags in to your toolchain, you can define a custom `riscv-none-elf` toolchain in your repo.
+If you want to bake certain compiler flags in to your toolchain, you can define
+a custom toolchain in your repo.
 
 In a BUILD file:
 
 ```python
 # path/to/toolchains/BUILD
 
-load("@toolchains_riscv_gnu//toolchain:toolchain.bzl", "riscv_none_elf_toolchain")
+load("@riscv_none_elf//toolchain:toolchain.bzl", "riscv_none_elf_toolchain")
 riscv_none_elf_toolchain(
     name = "custom_toolchain",
     target_compatible_with = [
@@ -129,7 +122,7 @@ riscv_none_elf_toolchain(
 And in your WORKSPACE / MODULE file:
 
 ```python
-register_toolchains("@//path/to/toolchains:all")
+register_toolchains("//path/to/toolchains:all")
 ```
 
 Be careful about registering the default toolchains when using a custom one

--- a/deps.bzl
+++ b/deps.bzl
@@ -125,7 +125,7 @@ def toolchains_riscv_gnu_deps(toolchain, toolchain_prefix, version, archives):
             **attrs
         )
 
-def riscv_none_elf_deps(version, archives = riscv_none_elf):
+def riscv_none_elf_deps(version = "13.2.0-2", archives = riscv_none_elf):
     """Workspace dependencies for the arm none eabi gcc toolchain
 
     Args:

--- a/deps.bzl
+++ b/deps.bzl
@@ -94,7 +94,18 @@ toolchains_riscv_gnu_repo = repository_rule(
 )
 
 def toolchains_riscv_gnu_deps(toolchain, toolchain_prefix, version, archives):
-    archive = archives[version]
+    """Define dependencies for a riscv toolchain.
+
+    Args:
+        toolchain: The name of the toolchain.
+        toolchain_prefix: The prefix of the toolchain.
+        version: The version of the toolchain.
+        archives: A dictionary of version to archive attributes.
+    """
+    archive = archives.get(version)
+
+    if not archive:
+        fail("Version {} not available in {}".format(version, archives.keys()))
 
     toolchains_riscv_gnu_repo(
         name = toolchain,
@@ -114,7 +125,7 @@ def toolchains_riscv_gnu_deps(toolchain, toolchain_prefix, version, archives):
             **attrs
         )
 
-def riscv_none_elf_deps(version = "13.2.0-2", archives = riscv_none_elf):
+def riscv_none_elf_deps(version, archives = riscv_none_elf):
     """Workspace dependencies for the arm none eabi gcc toolchain
 
     Args:

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,6 +1,7 @@
 """deps.bzl"""
 
 load("@toolchains_riscv_gnu//toolchain/archives:riscv_none_elf.bzl", "riscv_none_elf")
+load("@toolchains_riscv_gnu//toolchain:toolchain.bzl", "tools")
 
 def _riscv_gnu_cross_hosted_platform_specific_repo_impl(repository_ctx):
     """Defines a host-specific repository for the ARM GNU toolchain."""
@@ -9,6 +10,7 @@ def _riscv_gnu_cross_hosted_platform_specific_repo_impl(repository_ctx):
         url = repository_ctx.attr.url,
         stripPrefix = repository_ctx.attr.strip_prefix,
     )
+
     repository_ctx.template(
         "BUILD.bazel",
         Label("@toolchains_riscv_gnu//toolchain:templates/compiler.BUILD"),
@@ -16,8 +18,10 @@ def _riscv_gnu_cross_hosted_platform_specific_repo_impl(repository_ctx):
             "%toolchain_prefix%": repository_ctx.attr.toolchain_prefix,
             "%version%": repository_ctx.attr.version.split("-")[0],
             "%bin_extension%": ".exe" if "windows" in repository_ctx.name else "",
+            "%tools%": "{}".format(repository_ctx.attr.tools),
         },
     )
+
     for patch in repository_ctx.attr.patches:
         repository_ctx.patch(patch, strip = 1)
 
@@ -30,6 +34,8 @@ riscv_gnu_cross_hosted_platform_specific_repo = repository_rule(
         "version": attr.string(mandatory = True),
         "strip_prefix": attr.string(),
         "patches": attr.label_list(),
+        "tools": attr.string_list(default = tools),
+        "exec_compatible_with": attr.string_list(),
     },
 )
 
@@ -55,24 +61,53 @@ def _riscv_gnu_toolchain_repo_impl(repository_ctx):
         },
     )
 
+    repository_ctx.template(
+        "toolchain/toolchain.bzl",
+        Label("@toolchains_riscv_gnu//toolchain:templates/toolchain.bazel"),
+        substitutions = {
+            "%toolchain_name%": repository_ctx.attr.toolchain_name,
+            "%version%": repository_ctx.attr.version,
+            "%toolchain_prefix%": repository_ctx.attr.toolchain_prefix,
+            "%hosts%": "{}".format(repository_ctx.attr.hosts),
+        },
+    )
+
+    for repo in repository_ctx.attr.hosts.keys():
+        repository_ctx.template(
+            "toolchain/{}/BUILD".format(repo),
+            Label("@toolchains_riscv_gnu//toolchain:templates/alias.BUILD"),
+            substitutions = {
+                "%repo%": repo,
+                "%tools%": "{}".format(repository_ctx.attr.tools),
+            },
+        )
+
 toolchains_riscv_gnu_repo = repository_rule(
     implementation = _riscv_gnu_toolchain_repo_impl,
     attrs = {
         "toolchain_name": attr.string(mandatory = True),
         "toolchain_prefix": attr.string(mandatory = True),
         "version": attr.string(mandatory = True),
+        "hosts": attr.string_list_dict(mandatory = True),
+        "tools": attr.string_list(default = tools),
     },
 )
 
 def toolchains_riscv_gnu_deps(toolchain, toolchain_prefix, version, archives):
+    archive = archives[version]
+
     toolchains_riscv_gnu_repo(
         name = toolchain,
         toolchain_name = toolchain,
         toolchain_prefix = toolchain_prefix,
         version = version,
+        hosts = {
+            repo["name"]: repo["exec_compatible_with"]
+            for repo in archive
+        },
     )
 
-    for attrs in archives[version]:
+    for attrs in archive:
         riscv_gnu_cross_hosted_platform_specific_repo(
             toolchain_prefix = toolchain_prefix,
             version = version,

--- a/examples/toolchain/MODULE.bazel
+++ b/examples/toolchain/MODULE.bazel
@@ -15,16 +15,6 @@ local_path_override(
 
 riscv_toolchain = use_extension("@toolchains_riscv_gnu//:extensions.bzl", "riscv_toolchain")
 riscv_toolchain.riscv_none_elf(version = "13.2.1")
-use_repo(
-    riscv_toolchain,
-    "riscv_none_elf",
-    "riscv_none_elf_darwin_arm64",
-    "riscv_none_elf_darwin_x86_64",
-    "riscv_none_elf_linux_aarch64",
-    "riscv_none_elf_linux_x86_64",
-    "riscv_none_elf_windows_x86_64",
-)
+use_repo(riscv_toolchain, "riscv_none_elf")
 
-register_toolchains(
-    "//toolchains:all",
-)
+register_toolchains("//toolchains:all")

--- a/examples/toolchain/toolchains/BUILD
+++ b/examples/toolchain/toolchains/BUILD
@@ -1,4 +1,4 @@
-load("@toolchains_riscv_gnu//toolchain:toolchain.bzl", "riscv_none_elf_toolchain")
+load("@riscv_none_elf//toolchain:toolchain.bzl", "riscv_none_elf_toolchain")
 
 riscv_none_elf_toolchain(
     name = "rv32imac",

--- a/test/toolchains/BUILD
+++ b/test/toolchains/BUILD
@@ -1,4 +1,4 @@
-load("@toolchains_riscv_gnu//toolchain:toolchain.bzl", "riscv_none_elf_toolchain")
+load("@riscv_none_elf//toolchain:toolchain.bzl", "riscv_none_elf_toolchain")
 
 riscv_none_elf_toolchain(
     name = "riscv32_imac",

--- a/toolchain/archives/generate.py
+++ b/toolchain/archives/generate.py
@@ -24,6 +24,13 @@ RISCV_NONE_ELF = {
         "linux_x86_64": "linux-x64",
         "windows_x86_64": "win32-x64",
     },
+    "constraints": {
+        "darwin_arm64": ["@platforms//os:macos", "@platforms//cpu:arm64"],
+        "darwin_x86_64": ["@platforms//os:macos", "@platforms//cpu:x86_64"],
+        "linux_aarch64": ["@platforms//os:linux", "@platforms//cpu:arm64"],
+        "linux_x86_64": ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+        "windows_x86_64": ["@platforms//os:windows", "@platforms//cpu:x86_64"],
+    },
 }
 
 
@@ -45,8 +52,7 @@ def github_release_tags(owner, repo, count=1):
     return [release["tag_name"][1:] for release in reversed(releases[:count])]
 
 
-
-def generate_archive(name, prefix, version, system, template):
+def generate_archive(name, prefix, version, system, template, constraints):
     """Generate an archive dictionary for a given toolchain"""
     info = {
         "prefix": prefix,
@@ -61,10 +67,11 @@ def generate_archive(name, prefix, version, system, template):
         "url": url,
         "sha256": sha256,
         "strip_prefix": template["strip"].format(**info),
+        "exec_compatible_with": constraints,
     }
 
 
-def generate_release(name, prefix, hosts, template, releases):
+def generate_release(name, prefix, hosts, template, releases, constraints):
     """Generate a release dictionary for a given toolchain"""
     return {
         version: [
@@ -74,6 +81,7 @@ def generate_release(name, prefix, hosts, template, releases):
                 version=version,
                 system=system,
                 template=template,
+                constraints=constraints[host],
             )
             for host, system in hosts.items()
         ]

--- a/toolchain/archives/riscv_none_elf.bzl
+++ b/toolchain/archives/riscv_none_elf.bzl
@@ -7,30 +7,50 @@ riscv_none_elf = {
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v11.3.0-1/xpack-riscv-none-elf-gcc-11.3.0-1-darwin-arm64.tar.gz",
             "sha256": "e3fda6401ea1a055a90bfe3116f4d46fdc9201280df7c3991bb964f4bad18886",
             "strip_prefix": "xpack-riscv-none-elf-gcc-11.3.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_darwin_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v11.3.0-1/xpack-riscv-none-elf-gcc-11.3.0-1-darwin-x64.tar.gz",
             "sha256": "67c2f2d9bb530948610400e2b43aeef8a1d4913fae275b1edf04968019fb19b9",
             "strip_prefix": "xpack-riscv-none-elf-gcc-11.3.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_aarch64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v11.3.0-1/xpack-riscv-none-elf-gcc-11.3.0-1-linux-arm64.tar.gz",
             "sha256": "2cd91f4bcc0c7a0f5b5beead3be834f6708d7a196f94f7728ac68e1ad06cee24",
             "strip_prefix": "xpack-riscv-none-elf-gcc-11.3.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v11.3.0-1/xpack-riscv-none-elf-gcc-11.3.0-1-linux-x64.tar.gz",
             "sha256": "1c99fb1573ff2ed5deffce64cb96bb9272f351f054684c49dfd5ad41c6dd804d",
             "strip_prefix": "xpack-riscv-none-elf-gcc-11.3.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_windows_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v11.3.0-1/xpack-riscv-none-elf-gcc-11.3.0-1-win32-x64.zip",
             "sha256": "56cc2e340bdcaa718862b3526a7c550605e699847a8903e471336ba0a4535c68",
             "strip_prefix": "xpack-riscv-none-elf-gcc-11.3.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64",
+            ],
         },
     ],
     "12.1.0-1": [
@@ -39,30 +59,50 @@ riscv_none_elf = {
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.1.0-1/xpack-riscv-none-elf-gcc-12.1.0-1-darwin-arm64.tar.gz",
             "sha256": "a3eb788e1e5485e951ff1067ddf174c35f296540bfeb9e2a4dfd452a72b7c18e",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.1.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_darwin_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.1.0-1/xpack-riscv-none-elf-gcc-12.1.0-1-darwin-x64.tar.gz",
             "sha256": "6ab43e586728af78ef2aede74cea976836a3bfec9e970b5cbbd7bdd30788e992",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.1.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_aarch64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.1.0-1/xpack-riscv-none-elf-gcc-12.1.0-1-linux-arm64.tar.gz",
             "sha256": "78f9b63a97f378239cd447fdda54e7dd19d2823ee282b27f3e65aac398eedabb",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.1.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.1.0-1/xpack-riscv-none-elf-gcc-12.1.0-1-linux-x64.tar.gz",
             "sha256": "d6dc108ab53a41df3036f57cae4d0e538fb0d47c7b4d5fc8bb1b5499a64a2cdc",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.1.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_windows_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.1.0-1/xpack-riscv-none-elf-gcc-12.1.0-1-win32-x64.zip",
             "sha256": "7b79381242dbb3838e7f6a832dfd2628c7f6b36d9be793649ebaebad14cacbd9",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.1.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64",
+            ],
         },
     ],
     "12.1.0-2": [
@@ -71,30 +111,50 @@ riscv_none_elf = {
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.1.0-2/xpack-riscv-none-elf-gcc-12.1.0-2-darwin-arm64.tar.gz",
             "sha256": "e3532f8cc17969da85dd615108c5b2826eecacc7f003c0ba5914c03e3160af1c",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.1.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_darwin_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.1.0-2/xpack-riscv-none-elf-gcc-12.1.0-2-darwin-x64.tar.gz",
             "sha256": "39bd9eb7df484309fb1c725ae806b16589b8d90f273419b2a41e4017886b2176",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.1.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_aarch64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.1.0-2/xpack-riscv-none-elf-gcc-12.1.0-2-linux-arm64.tar.gz",
             "sha256": "66a81676aff6051d6e602f336f6c8ae9ca4dec483b45adbbf747dc022768653e",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.1.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.1.0-2/xpack-riscv-none-elf-gcc-12.1.0-2-linux-x64.tar.gz",
             "sha256": "0df95d28487b5e55eb48c487bfc8951a23ef97080a8621dd4109586f51dc177e",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.1.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_windows_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.1.0-2/xpack-riscv-none-elf-gcc-12.1.0-2-win32-x64.zip",
             "sha256": "ab2a596d00a4436192b80381b4b9bc1e6962de5699b4a494c4f476216963983d",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.1.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64",
+            ],
         },
     ],
     "12.2.0-1": [
@@ -103,30 +163,50 @@ riscv_none_elf = {
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-1/xpack-riscv-none-elf-gcc-12.2.0-1-darwin-arm64.tar.gz",
             "sha256": "4a0044c4c8e3115abe32030b80a136ab987fc2a0712b0ddf62d11d369a5ad521",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_darwin_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-1/xpack-riscv-none-elf-gcc-12.2.0-1-darwin-x64.tar.gz",
             "sha256": "08508cc24201452a8f82bb12f9ee9474704d2d5db342205ae25567baca8de061",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_aarch64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-1/xpack-riscv-none-elf-gcc-12.2.0-1-linux-arm64.tar.gz",
             "sha256": "68ff464c907c8160308a32babba49ccb0493e480520d5c8513373301e65e7ee2",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-1/xpack-riscv-none-elf-gcc-12.2.0-1-linux-x64.tar.gz",
             "sha256": "04b5f45d609b221505e9232b1b63ae6cdb17d0a23f13ce9c231fc4008753a58a",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_windows_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-1/xpack-riscv-none-elf-gcc-12.2.0-1-win32-x64.zip",
             "sha256": "1edf87d32975619076d3df558b8c1218daa54947f47b06c7ea9edb99e2290548",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64",
+            ],
         },
     ],
     "12.2.0-2": [
@@ -135,30 +215,50 @@ riscv_none_elf = {
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-2/xpack-riscv-none-elf-gcc-12.2.0-2-darwin-arm64.tar.gz",
             "sha256": "16480bd25ee7f9f94d2a5aa5ad3b81a5bce96841ee89ba9afa27220a58a55240",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_darwin_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-2/xpack-riscv-none-elf-gcc-12.2.0-2-darwin-x64.tar.gz",
             "sha256": "85812c885e5e3359ce03a842222d1a738e664bc9fc14096680699c103020eceb",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_aarch64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-2/xpack-riscv-none-elf-gcc-12.2.0-2-linux-arm64.tar.gz",
             "sha256": "207e96dfac200b2b119285a0c65a928a059963d2eeda37d8f979cfa9b7d7dcc8",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-2/xpack-riscv-none-elf-gcc-12.2.0-2-linux-x64.tar.gz",
             "sha256": "bc3bb92b7258bbc60aa763aef3f435a41917f1588e9c0da142815225fe3a43f4",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_windows_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-2/xpack-riscv-none-elf-gcc-12.2.0-2-win32-x64.zip",
             "sha256": "31d94eeb94829a8c3044a5b37436c08a9db8ea2dbdb38e1b3f62c93f5f94a60a",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64",
+            ],
         },
     ],
     "12.2.0-3": [
@@ -167,94 +267,50 @@ riscv_none_elf = {
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-3/xpack-riscv-none-elf-gcc-12.2.0-3-darwin-arm64.tar.gz",
             "sha256": "56967546a79f9f8034d755fd3df409f4c6ab64cb4a84ef0f6f881f8348e20f37",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-3",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_darwin_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-3/xpack-riscv-none-elf-gcc-12.2.0-3-darwin-x64.tar.gz",
             "sha256": "f277d63d7540f50a57cc1df98911a5721e824f84ad22da37d81fa044bab18126",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-3",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_aarch64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-3/xpack-riscv-none-elf-gcc-12.2.0-3-linux-arm64.tar.gz",
             "sha256": "64c70bb0b817bb9d9a700015bbb66450a7f238649346dd680bc897c783c68fb5",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-3",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-3/xpack-riscv-none-elf-gcc-12.2.0-3-linux-x64.tar.gz",
             "sha256": "0bb5f0c6a36f5197888fcd176e3734ec5b74167b5a631883f72ae3cbd47a97c3",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-3",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_windows_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.2.0-3/xpack-riscv-none-elf-gcc-12.2.0-3-win32-x64.zip",
             "sha256": "ced0ba39ed89048f176c9c93174b170443d2dbe669e9a6ddb92c3cfde689578e",
             "strip_prefix": "xpack-riscv-none-elf-gcc-12.2.0-3",
-        },
-    ],
-    "12.3.0-1": [
-        {
-            "name": "riscv_none_elf_darwin_arm64",
-            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-darwin-arm64.tar.gz",
-            "sha256": "54150de972a3e28dee14fc341f5c46f3d25654ac66a23e8e295f68ec8171648a",
-            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-1",
-        },
-        {
-            "name": "riscv_none_elf_darwin_x86_64",
-            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-darwin-x64.tar.gz",
-            "sha256": "65d50dd2a87f4fd707d4859d4278a8eb01a6bfbba59ed07b5fbf7051a19ae4db",
-            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-1",
-        },
-        {
-            "name": "riscv_none_elf_linux_aarch64",
-            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-linux-arm64.tar.gz",
-            "sha256": "6dfb0390838ea37beab031d426e56ca707f0e7b3ec7fea987e4c1ff748b6d3f1",
-            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-1",
-        },
-        {
-            "name": "riscv_none_elf_linux_x86_64",
-            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-linux-x64.tar.gz",
-            "sha256": "0a7f71150e7b284a01ef739a17a32bafce5db43c012d734d57be5a8c2e2b57b6",
-            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-1",
-        },
-        {
-            "name": "riscv_none_elf_windows_x86_64",
-            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-win32-x64.zip",
-            "sha256": "58f3274a990815b87a29e64560dc57c192f9a45b1effc1106f607a50b7f6ccf0",
-            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-1",
-        },
-    ],
-    "12.3.0-2": [
-        {
-            "name": "riscv_none_elf_darwin_arm64",
-            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-darwin-arm64.tar.gz",
-            "sha256": "211f85c5a577069032982dfba1244af513ae2d075e1ee43bddf03bcd8673c02f",
-            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-2",
-        },
-        {
-            "name": "riscv_none_elf_darwin_x86_64",
-            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-darwin-x64.tar.gz",
-            "sha256": "ef312ce2d7cfd7e667ca10f0ce7a3f0805c0c02e159cedeb9448bff7de236bcb",
-            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-2",
-        },
-        {
-            "name": "riscv_none_elf_linux_aarch64",
-            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-linux-arm64.tar.gz",
-            "sha256": "09343a15feafa1b370436d806dc4efba5bce02586ef7f317a894c16615213c27",
-            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-2",
-        },
-        {
-            "name": "riscv_none_elf_linux_x86_64",
-            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-linux-x64.tar.gz",
-            "sha256": "9921d63c04611954af016b9ca74cd52c1ccb832800d321d67e4e651f16146d16",
-            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-2",
-        },
-        {
-            "name": "riscv_none_elf_windows_x86_64",
-            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-win32-x64.zip",
-            "sha256": "87e851ebda6a179e988a33b58593c00e13f6edc55c3c73f913d28f10ab983653",
-            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64",
+            ],
         },
     ],
     "13.2.0-1": [
@@ -263,30 +319,154 @@ riscv_none_elf = {
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-1/xpack-riscv-none-elf-gcc-13.2.0-1-darwin-arm64.tar.gz",
             "sha256": "a32037a72288f87b356aefde49e474ad9016f90bb7ad37546bb8f916e58c47e7",
             "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_darwin_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-1/xpack-riscv-none-elf-gcc-13.2.0-1-darwin-x64.tar.gz",
             "sha256": "5b3139c3c3b8a1b49c7791a022d8155c2a16e9d1a02469055027e40a41b288d0",
             "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_aarch64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-1/xpack-riscv-none-elf-gcc-13.2.0-1-linux-arm64.tar.gz",
             "sha256": "6df6ac0dfd2b56a7fe4a2fac74abf7c391a99a906e69aebea097757450683b50",
             "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-1/xpack-riscv-none-elf-gcc-13.2.0-1-linux-x64.tar.gz",
             "sha256": "d7eff5c5d778873c3d486e5d2c805b82582e73081f93edb375a1ef5d84764b43",
             "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_windows_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-1/xpack-riscv-none-elf-gcc-13.2.0-1-win32-x64.zip",
             "sha256": "9e952f2a6b4c423f3df208391c836c7ff67ffee8df7aae6ca8efc59110bd14b7",
             "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64",
+            ],
+        },
+    ],
+    "12.3.0-1": [
+        {
+            "name": "riscv_none_elf_darwin_arm64",
+            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-darwin-arm64.tar.gz",
+            "sha256": "54150de972a3e28dee14fc341f5c46f3d25654ac66a23e8e295f68ec8171648a",
+            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:arm64",
+            ],
+        },
+        {
+            "name": "riscv_none_elf_darwin_x86_64",
+            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-darwin-x64.tar.gz",
+            "sha256": "65d50dd2a87f4fd707d4859d4278a8eb01a6bfbba59ed07b5fbf7051a19ae4db",
+            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:x86_64",
+            ],
+        },
+        {
+            "name": "riscv_none_elf_linux_aarch64",
+            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-linux-arm64.tar.gz",
+            "sha256": "6dfb0390838ea37beab031d426e56ca707f0e7b3ec7fea987e4c1ff748b6d3f1",
+            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:arm64",
+            ],
+        },
+        {
+            "name": "riscv_none_elf_linux_x86_64",
+            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-linux-x64.tar.gz",
+            "sha256": "0a7f71150e7b284a01ef739a17a32bafce5db43c012d734d57be5a8c2e2b57b6",
+            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:x86_64",
+            ],
+        },
+        {
+            "name": "riscv_none_elf_windows_x86_64",
+            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-1/xpack-riscv-none-elf-gcc-12.3.0-1-win32-x64.zip",
+            "sha256": "58f3274a990815b87a29e64560dc57c192f9a45b1effc1106f607a50b7f6ccf0",
+            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-1",
+            "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64",
+            ],
+        },
+    ],
+    "12.3.0-2": [
+        {
+            "name": "riscv_none_elf_darwin_arm64",
+            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-darwin-arm64.tar.gz",
+            "sha256": "211f85c5a577069032982dfba1244af513ae2d075e1ee43bddf03bcd8673c02f",
+            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:arm64",
+            ],
+        },
+        {
+            "name": "riscv_none_elf_darwin_x86_64",
+            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-darwin-x64.tar.gz",
+            "sha256": "ef312ce2d7cfd7e667ca10f0ce7a3f0805c0c02e159cedeb9448bff7de236bcb",
+            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:x86_64",
+            ],
+        },
+        {
+            "name": "riscv_none_elf_linux_aarch64",
+            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-linux-arm64.tar.gz",
+            "sha256": "09343a15feafa1b370436d806dc4efba5bce02586ef7f317a894c16615213c27",
+            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:arm64",
+            ],
+        },
+        {
+            "name": "riscv_none_elf_linux_x86_64",
+            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-linux-x64.tar.gz",
+            "sha256": "9921d63c04611954af016b9ca74cd52c1ccb832800d321d67e4e651f16146d16",
+            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:x86_64",
+            ],
+        },
+        {
+            "name": "riscv_none_elf_windows_x86_64",
+            "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v12.3.0-2/xpack-riscv-none-elf-gcc-12.3.0-2-win32-x64.zip",
+            "sha256": "87e851ebda6a179e988a33b58593c00e13f6edc55c3c73f913d28f10ab983653",
+            "strip_prefix": "xpack-riscv-none-elf-gcc-12.3.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64",
+            ],
         },
     ],
     "13.2.0-2": [
@@ -295,30 +475,50 @@ riscv_none_elf = {
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-darwin-arm64.tar.gz",
             "sha256": "dfe3123e5e5093b165eaaf18401b802cbb8697f5ec9b0f5cfd99c45e848fd8a7",
             "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_darwin_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-darwin-x64.tar.gz",
             "sha256": "72e65bcad6360eb059096a0fb77f3e3e6c618b1281b89648056c95d1b2749466",
             "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:macos",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_aarch64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-arm64.tar.gz",
             "sha256": "1c981c611a38dfe5af902089aed570d4dd501eb4ed88d801043e59ab9a62a86a",
             "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:arm64",
+            ],
         },
         {
             "name": "riscv_none_elf_linux_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz",
             "sha256": "52545afb900200fbf65fe05f7ce7090b8a42c64091f4f5d43cae6bb68ea2434a",
             "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:linux",
+                "@platforms//cpu:x86_64",
+            ],
         },
         {
             "name": "riscv_none_elf_windows_x86_64",
             "url": "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-win32-x64.zip",
             "sha256": "28ce9f0cfa09f8d4c638a59fb4e17e3f61c80c47e46f11b2ba505a2a3db602f8",
             "strip_prefix": "xpack-riscv-none-elf-gcc-13.2.0-2",
+            "exec_compatible_with": [
+                "@platforms//os:windows",
+                "@platforms//cpu:x86_64",
+            ],
         },
     ],
 }

--- a/toolchain/templates/alias.BUILD
+++ b/toolchain/templates/alias.BUILD
@@ -1,0 +1,24 @@
+"""
+This BUILD file is used to alias host toolchains in the generated repo, allowing
+users to register a custom toolchain without having to import the host repo
+"""
+
+HOST = "%repo%"
+TOOLS = %tools%
+
+[
+    alias(
+        name = name,
+        actual = "@{repo}//:{name}".format(repo=HOST, name=name),
+        visibility = ["//visibility:public"],
+    )
+    for name in TOOLS + [
+        "include_path",
+        "library_path",
+        "compiler_pieces",
+        "compiler_files",
+        "ar_files",
+        "linker_files",
+        "compiler_components",
+    ]
+]

--- a/toolchain/templates/compiler.BUILD
+++ b/toolchain/templates/compiler.BUILD
@@ -3,8 +3,6 @@ This BUILD file marks the top of the host-specific cross-toolchain repository.
 If the host needs @riscv_none_elf_linux_x86_64, this is the build file at the
 top of that repository.
 """
-load("@toolchains_riscv_gnu//toolchain:toolchain.bzl", "tools")
-
 package(default_visibility = ["//visibility:public"])
 
 # export the executable files to make them available for direct use.
@@ -12,6 +10,7 @@ exports_files(glob(["**"], exclude_directories = 0))
 
 PREFIX = "%toolchain_prefix%"
 VERSION = "%version%"
+TOOLS = %tools%
 
 # executables.
 [
@@ -19,7 +18,7 @@ VERSION = "%version%"
         name = tool,
         srcs = ["bin/{}-{}%bin_extension%".format(PREFIX, tool)],
     )
-    for tool in tools
+    for tool in TOOLS
 ]
 
 filegroup(

--- a/toolchain/templates/toolchain.bazel
+++ b/toolchain/templates/toolchain.bazel
@@ -1,0 +1,67 @@
+load("@toolchains_riscv_gnu//toolchain:config.bzl", "cc_riscv_gnu_toolchain_config")
+load("@rules_cc//cc:defs.bzl", "cc_toolchain")
+
+HOSTS = %hosts%
+
+
+def %toolchain_name%_toolchain(
+        name,
+        version = "%version%",
+        toolchain = "",
+        gcc_tool = "gcc",
+        abi_version = "",
+        copts = [],
+        linkopts = [],
+        target_compatible_with = [],
+        include_std = False
+    ):
+    """
+    Create an riscv-none-elf toolchain with the given configuration.
+
+    Args:
+        name: The name of the toolchain.
+        version: The version of the gcc toolchain.
+        **kwargs: same as toolchains_riscv_gnu
+    """
+    for host_repo, exec_compatible_with in HOSTS.items():
+
+        alias_repo = "@%toolchain_name%//toolchain/{}".format(host_repo)
+
+        cc_riscv_gnu_toolchain_config(
+            name = "config_{}_{}".format(name, host_repo),
+            gcc_repo = host_repo,
+            gcc_version = version,
+            gcc_tool = gcc_tool,
+            abi_version = abi_version,
+            host_system_name = host_repo,
+            toolchain_prefix = "%toolchain_prefix%",
+            toolchain_identifier = host_repo,
+            toolchain_bins = "{}:compiler_components".format(alias_repo),
+            include_path = ["{}:include_path".format(alias_repo)],
+            library_path = ["{}:library_path".format(alias_repo)],
+            copts = copts,
+            linkopts = linkopts,
+            include_std = include_std,
+        )
+
+        cc_toolchain(
+            name = "cc_toolchain_{}_{}".format(name, host_repo),
+            all_files = "{}:compiler_pieces".format(alias_repo),
+            ar_files = "{}:ar_files".format(alias_repo),
+            compiler_files = "{}:compiler_files".format(alias_repo),
+            dwp_files = ":empty",
+            linker_files = "{}:linker_files".format(alias_repo),
+            objcopy_files = "{}:objcopy".format(alias_repo),
+            strip_files = "{}:strip".format(alias_repo),
+            supports_param_files = 0,
+            toolchain_config = ":config_{}_{}".format(name, host_repo),
+            toolchain_identifier = host_repo,
+        )
+
+        native.toolchain(
+            name = "{}_{}".format(name, host_repo),
+            exec_compatible_with = exec_compatible_with,
+            target_compatible_with = target_compatible_with,
+            toolchain = ":cc_toolchain_{}_{}".format(name, host_repo),
+            toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+        )

--- a/toolchain/toolchain.bzl
+++ b/toolchain/toolchain.bzl
@@ -51,7 +51,6 @@ def _riscv_gnu_toolchain(
         version = "",
         include_std = False):
     for host, exec_compatible_with in hosts[toolchain_prefix].items():
-
         cc_riscv_gnu_toolchain_config(
             name = "config_{}_{}".format(host, name),
             gcc_repo = "{}_{}".format(toolchain, host),

--- a/toolchain/toolchain.bzl
+++ b/toolchain/toolchain.bzl
@@ -51,11 +51,6 @@ def _riscv_gnu_toolchain(
         version = "",
         include_std = False):
     for host, exec_compatible_with in hosts[toolchain_prefix].items():
-        fix_linkopts = []
-
-        # macOS on apple rejects the relative path LTO plugin
-        if version == "13.2.1" and "darwin" in host:
-            fix_linkopts.append("-fno-lto")
 
         cc_riscv_gnu_toolchain_config(
             name = "config_{}_{}".format(host, name),
@@ -70,7 +65,7 @@ def _riscv_gnu_toolchain(
             include_path = ["@{}_{}//:include_path".format(toolchain, host)],
             library_path = ["@{}_{}//:library_path".format(toolchain, host)],
             copts = copts,
-            linkopts = linkopts + fix_linkopts,
+            linkopts = linkopts,
             include_std = include_std,
         )
 


### PR DESCRIPTION
# Description
Use aliased repos, in an attempt to incorporate a good suggestions from @fmeum in https://github.com/bazelbuild/bazel-central-registry/pull/1765

# Details

Now the MODULE file does not need to explicitly import the repos for each host toolchains, but instead uses aliased targets in the autogenerated `riscv_none_elf` repo. 

```python
bazel_dep(name = "toolchains_riscv_gnu", version="1.0.0")

riscv_toolchain = use_extension("@toolchains_riscv_gnu//:extensions.bzl", "riscv_toolchain")
riscv_toolchain.riscv_none_elf(version = "13.2.1")
use_repo(riscv_toolchain, "riscv_none_elf")
```

Note: this does not break backward compatibility, but eventually we might want to remove the old way of importing repos directly