### PR TITLE
fix: fix the empty glob error with bazel 8+

### DIFF
--- a/toolchain/templates/compiler.BUILD
+++ b/toolchain/templates/compiler.BUILD
@@ -38,7 +38,7 @@ filegroup(
     srcs = [
       PREFIX,
       "{}/lib".format(PREFIX),
-    ] + glob(["lib/gcc/{}/*".format(PREFIX)]),
+    ] + glob(["lib/gcc/{}/**".format(PREFIX)]),
 )
 
 # libraries, headers and executables.


### PR DESCRIPTION
Issue: #21